### PR TITLE
Auth tests: modal Sign-In flow + robust assertions

### DIFF
--- a/Pages/LoginPage.cs
+++ b/Pages/LoginPage.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium.Support.UI;
 using Reqnroll.BoDi;
 // MUST USE with ExpectedConditions
 using SeleniumExtras.WaitHelpers;
+using System.Numerics;
 
 namespace qa_dotnet_cucumber.Pages
 {
@@ -10,20 +11,36 @@ namespace qa_dotnet_cucumber.Pages
     {
         private readonly IWebDriver _driver;
         private readonly WebDriverWait _wait;
-        public IWebDriver Driver => _driver;  
+        public IWebDriver Driver => _driver;
 
         // Locators
-        private readonly By UsernameField = By.Id("username");
-        private readonly By PasswordField = By.Id("password");
-        private readonly By LoginButton = By.CssSelector("button[type='submit']");
-        private readonly By SuccessMessage = By.CssSelector(".flash.success");
+        private readonly By SignInLink = By.XPath("//a[normalize-space()='Sign In']");
+        private readonly By UsernameField = By.XPath("//input[@type='email' or @placeholder='Email address' or @name='Email' or @id='email']");
+        private readonly By PasswordField = By.CssSelector("input[type='password']");
+        private readonly By LoginButton = By.XPath("//button[normalize-space()='Login']");
+        private readonly By SuccessMessage = By.XPath("//button[normalize-space()='Sign Out' ] | //a[normalize-space()='Sign Out' ]");
+
+
+        private readonly By PasswordErrorPrompt = By.XPath("//div[text()='Password must be at least 6 characters']");
+
+        private readonly By EmailErrorPrompt = By.XPath("//div[text()='Please enter a valid email address']");
+
+        private readonly By ErrorToast = By.XPath("//div[@class='ns-box-inner' and text()='Confirm your email']");
+    
+
 
         public LoginPage(IWebDriver driver) // Inject IWebDriver directly
         {
             _driver = driver;
             _wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10)); // 10-second timeout
         }
-        
+        public void OpenSignIn()
+        {
+            var signIn = _wait.Until(
+        SeleniumExtras.WaitHelpers.ExpectedConditions.ElementToBeClickable(
+            By.XPath("//a[normalize-space()='Sign In']")));
+            signIn.Click();
+        }
         public void Login(string username, string password)
         {
             var usernameElement = _wait.Until(ExpectedConditions.ElementIsVisible(UsernameField));
@@ -40,10 +57,32 @@ namespace qa_dotnet_cucumber.Pages
         {
             return _wait.Until(d => d.FindElement(SuccessMessage)).Text;
         }
+        public string GetEmailInlineError()
+        {
+            var el = _wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.ElementIsVisible(EmailErrorPrompt));
+            return el.Text.Trim();
+        }
+
+        public string GetPasswordInlineError()
+        {
+            var el = _wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.ElementIsVisible(PasswordErrorPrompt));
+            return el.Text.Trim();
+        }
+
+        public string GetPopupError()
+        {
+            var el = _wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.ElementIsVisible(ErrorToast));
+            return el.Text.Trim();
+        }
 
         public bool IsAtLoginPage()
         {
-            return _driver.Title.Contains("The Internet");
+            try
+            {
+                _wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.ElementIsVisible(UsernameField));
+                return true; // username field visible ⇒ login modal/page is open
+            }
+            catch { return false; }
         }
     }
 }

--- a/Steps/LoginSteps.cs
+++ b/Steps/LoginSteps.cs
@@ -21,14 +21,15 @@ namespace qa_dotnet_cucumber.Steps
         [Given("I am on the login page")]
         public void GivenIAmOnTheLoginPage()
         {
-            _navigationHelper.NavigateTo("/login");
+            _navigationHelper.NavigateTo("/");
+            _loginPage.OpenSignIn();
             Assert.That(_loginPage.IsAtLoginPage(), Is.True, "Should be on the login page");
         }
 
         [When("I enter valid credentials")]
         public void WhenIEnterValidCredentials()
         {
-            _loginPage.Login("tomsmith", "SuperSecretPassword!");
+            _loginPage.Login("annie.jose1202@gmail.com", "123456");
         }
 
         [When("I enter an invalid username and valid password")]
@@ -53,18 +54,51 @@ namespace qa_dotnet_cucumber.Steps
         public void ThenIShouldSeeTheSecureArea()
         {
             var successMessage = _loginPage.GetSuccessMessage();
-            Assert.That(successMessage, Does.Contain("You logged into a secure area!"), "Should see successful login message");
+            Assert.That(successMessage, Does.Contain("Sign Out"), "Expected Sign Out to be visible after login.");
+
         }
 
         [Then("I should see an error message")]
         public void ThenIShouldSeeAnErrorMessage()
         {
-            // Use LoginPage's driver to wait for and verify the error message
-            var wait = new WebDriverWait(_loginPage.Driver, TimeSpan.FromSeconds(10));
-            var errorMessageElement = wait.Until(d => d.FindElement(By.CssSelector(".flash.error")));
-            var errorMessage = errorMessageElement.Text;
-            Assert.That(errorMessage, Does.Match("Your username is invalid!|Your password is invalid!|Username is required"), 
-                "Should see an appropriate error message");
+            var d = _loginPage.Driver;
+            var wait = new WebDriverWait(d, TimeSpan.FromSeconds(10));
+
+            // 1) Inline field prompts (empty/invalid input)
+            var emailPrompt = d.FindElements(By.XPath(
+                "//input[@type='email' or @placeholder='Email address' or @name='Email' or @id='email']" +
+                "/following-sibling::*[contains(@class,'prompt') and contains(@class,'red')]"
+            )).FirstOrDefault();
+
+            var passPrompt = d.FindElements(By.XPath(
+                "//input[@type='password']" +
+                "/following-sibling::*[contains(@class,'prompt') and contains(@class,'red')]"
+            )).FirstOrDefault();
+
+            if (emailPrompt != null || passPrompt != null)
+            {
+                if (emailPrompt != null)
+                    Assert.That(emailPrompt.Text.Trim(),
+                        Does.Match("valid|email|required").IgnoreCase,
+                        $"Unexpected email error: '{emailPrompt.Text}'");
+
+                if (passPrompt != null)
+                    Assert.That(passPrompt.Text.Trim(),
+                        Does.Match("at least 6|required|password").IgnoreCase,
+                        $"Unexpected password error: '{passPrompt.Text}'");
+                return; // done
+            }
+
+            // 2) Popup/toast (wrong password / invalid creds)
+            var toast = wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.ElementIsVisible(
+                By.CssSelector(".ns-box.ns-show, .ui.error.message, .negative.message, .alert-danger, .validation-summary-errors")
+            ));
+            var msg = toast.Text.Trim();
+
+            Assert.That(msg, Is.Not.Empty, "Expected an error popup.");
+            Assert.That(msg, Does.Match("invalid|incorrect|unauthor|confirm|verification|failed|required").IgnoreCase,
+                $"Unexpected popup text: '{msg}'");
         }
+
     }
 }

--- a/qa-dotnet-cucumber.csproj
+++ b/qa-dotnet-cucumber.csproj
@@ -44,4 +44,8 @@
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\Features\" />
+  </ItemGroup>
+
 </Project>

--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,6 @@
     "Title": "Test Automation Report"
   },
   "Environment": {
-    "BaseUrl": "http://the-internet.herokuapp.com"
+    "BaseUrl": "http://localhost:5003"
   }
 }


### PR DESCRIPTION
- Given: open Home -> click "Sign In", wait for email field

- Success: assert "Sign Out" visible (no flash banner)

- Errors: check inline prompts (email/password), fallback to toast

- LoginPage: XPath/CSS locators + OpenSignIn/Get*Error helpers